### PR TITLE
Exclude flux-system from flux constraints

### DIFF
--- a/charts/gatekeeper-library-constraints/Chart.yaml
+++ b/charts/gatekeeper-library-constraints/Chart.yaml
@@ -3,5 +3,5 @@ name: gatekeeper-library-constraints
 description: Library of gateeper constraints
 home: https://github.com/xenitab/gatekeeper-library
 type: application
-version: v0.6.0
-appVersion: v0.6.0
+version: v0.6.1
+appVersion: v0.6.1

--- a/charts/gatekeeper-library-constraints/generated/defaults.yaml
+++ b/charts/gatekeeper-library-constraints/generated/defaults.yaml
@@ -10,6 +10,8 @@ fluxdisablecrossnamespacesource:
         kinds: ["HelmRelease"]
       - apiGroups: ["kustomize.toolkit.fluxcd.io"]
         kinds: ["Kustomization"]
+    excludedNamespaces:
+      - "flux-system"
 fluxrequireserviceaccount:
   match:
     kinds:
@@ -17,6 +19,8 @@ fluxrequireserviceaccount:
         kinds: ["HelmRelease"]
       - apiGroups: ["kustomize.toolkit.fluxcd.io"]
         kinds: ["Kustomization"]
+    excludedNamespaces:
+      - "flux-system"
 k8spodpriorityclass:
   match:
     kinds:

--- a/charts/gatekeeper-library-templates/Chart.yaml
+++ b/charts/gatekeeper-library-templates/Chart.yaml
@@ -3,5 +3,5 @@ name: gatekeeper-library-templates
 description: Library of gateeper constraints
 home: https://github.com/xenitab/gatekeeper-library
 type: application
-version: v0.6.0
-appVersion: v0.6.0
+version: v0.6.1
+appVersion: v0.6.1

--- a/library/flux-disable-cross-namespace-source/constraint.yaml
+++ b/library/flux-disable-cross-namespace-source/constraint.yaml
@@ -9,3 +9,5 @@ spec:
         kinds: ["HelmRelease"]
       - apiGroups: ["kustomize.toolkit.fluxcd.io"]
         kinds: ["Kustomization"]
+    excludedNamespaces:
+      - "flux-system"

--- a/library/flux-require-service-account/constraint.yaml
+++ b/library/flux-require-service-account/constraint.yaml
@@ -9,3 +9,5 @@ spec:
         kinds: ["HelmRelease"]
       - apiGroups: ["kustomize.toolkit.fluxcd.io"]
         kinds: ["Kustomization"]
+    excludedNamespaces:
+      - "flux-system"


### PR DESCRIPTION
By default the flux-system namespace should be exluded from the
flux constraints. This is to avoid breaking flux-system as it does
not have a service account set. Additionally flux-system is a admin
namespace which should have greater access to the cluster.