### PR TITLE
Add helm chart labels to config

### DIFF
--- a/charts/gatekeeper-library-templates/Chart.yaml
+++ b/charts/gatekeeper-library-templates/Chart.yaml
@@ -3,5 +3,5 @@ name: gatekeeper-library-templates
 description: Library of gateeper constraints
 home: https://github.com/xenitab/gatekeeper-library
 type: application
-version: v0.7.4
-appVersion: v0.7.4
+version: v0.7.5
+appVersion: v0.7.5

--- a/charts/gatekeeper-library-templates/templates/_helpers.tpl
+++ b/charts/gatekeeper-library-templates/templates/_helpers.tpl
@@ -42,3 +42,11 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "gatekeeper-library.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "gatekeeper-library.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/gatekeeper-library-templates/templates/config.yaml
+++ b/charts/gatekeeper-library-templates/templates/config.yaml
@@ -15,6 +15,8 @@ apiVersion: config.gatekeeper.sh/v1alpha1
 kind: Config
 metadata:
   name: config
+  labels:
+    {{- include "gatekeeper-library.labels" . | nindent 4 }}
 spec:
   match:
     {{- toYaml .Values.exclude | nindent 4 }}


### PR DESCRIPTION
Have seen helm label issues when reinstalling gatkeeper-libary-templates.

```shell
│ Error: rendered manifests contain a resource that already exists. Unable to continue with install: Config "config" in namespace "gatekeeper-system" exists and cannot be imported into the current release: invalid ownership metadata; annotation validation error: missing key "meta.helm.sh/release-name": must be set to "gatekeeper-library-templates"; annotation validation error: missing key "meta.helm.sh/release-namespace": must be set to "gatekeeper-system"
```
