### PR TITLE
Update major version of yq in Makefile

### DIFF
--- a/.github/workflows/opa.yaml
+++ b/.github/workflows/opa.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Install yq
         shell: bash
         run: |
-          wget -q https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64
+          wget -q https://github.com/mikefarah/yq/releases/download/v4.19.1/yq_linux_amd64
           chmod +x yq_linux_amd64
           mkdir -p ~/.local/bin/
           mv ./yq_linux_amd64 ~/.local/bin/yq


### PR DESCRIPTION
The release of yq 3 is deprecated and does not receive bugfixes since
August 2021. This patch fixes all found changes between the 3 and 4.18.1
release, however the syntax has changed dramatically to closer reflect
the syntax used in jq, so a few hidden bugs are to be expected.