### PR TITLE
Pod disallow service account token by default

### DIFF
--- a/charts/gatekeeper-library-constraints/generated/pod-serviceaccount-token-false.yaml
+++ b/charts/gatekeeper-library-constraints/generated/pod-serviceaccount-token-false.yaml
@@ -1,0 +1,21 @@
+apiVersion: mutations.gatekeeper.sh/v1beta1
+kind: Assign
+metadata:
+  name: pod-serviceaccount-token-false
+spec:
+  match:
+    scope: Namespaced
+    kinds:
+      - apiGroups: ["*"]
+        kinds: ["Pod"]
+  applyTo:
+    - versions: ["v1"]
+      groups: [""]
+      kinds: ["Pod"]
+  location: "spec.securityContext.automountServiceAccountToken"
+  parameters:
+    assign:
+      value: false
+    pathTests:
+      - subPath: "spec.automountServiceAccountToken"
+        condition: MustNotExist

--- a/charts/gatekeeper-library-constraints/generated/pod-servicetoken-false.yaml
+++ b/charts/gatekeeper-library-constraints/generated/pod-servicetoken-false.yaml
@@ -1,0 +1,21 @@
+apiVersion: mutations.gatekeeper.sh/v1beta1
+kind: Assign
+metadata:
+  name: pod-servicetoken-false
+spec:
+  match:
+    scope: Namespaced
+    kinds:
+      - apiGroups: ["*"]
+        kinds: ["Pod"]
+  applyTo:
+    - versions: ["v1"]
+      groups: [""]
+      kinds: ["Pod"]
+  location: "spec.securityContext.automountServiceAccountToken"
+  parameters:
+    assign:
+      value: false
+    pathTests:
+      - subPath: "spec.automountServiceAccountToken"
+        condition: MustNotExist

--- a/library/assigns/pod-serviceaccount-token-false.yaml
+++ b/library/assigns/pod-serviceaccount-token-false.yaml
@@ -1,0 +1,21 @@
+apiVersion: mutations.gatekeeper.sh/v1beta1
+kind: Assign
+metadata:
+  name: pod-serviceaccount-token-false
+spec:
+  match:
+    scope: Namespaced
+    kinds:
+      - apiGroups: ["*"]
+        kinds: ["Pod"]
+  applyTo:
+    - versions: ["v1"]
+      groups: [""]
+      kinds: ["Pod"]
+  location: "spec.securityContext.automountServiceAccountToken"
+  parameters:
+    assign:
+      value: false
+    pathTests:
+      - subPath: "spec.automountServiceAccountToken"
+        condition: MustNotExist


### PR DESCRIPTION
Overall pods don't need k8s api tokens to run.
Disable it by default but you can opt in if needed.
Solves #47