### PR TITLE
Update kubectl image used in post upgrade hook

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Kubectl
         uses: azure/setup-kubectl@v1
         with:
-          version: "v1.21.2"
+          version: "v1.23.5"
       - name: Run e2e tests
         run: |
           make e2e

--- a/charts/gatekeeper-library-templates/templates/wait-for-crds.yaml
+++ b/charts/gatekeeper-library-templates/templates/wait-for-crds.yaml
@@ -59,5 +59,5 @@ spec:
       serviceAccountName: wait-for-crds
       containers:
       - name: wait-for-crds
-        image: quay.io/bitnami/kubectl:1.19.4
+        image: bitnami/kubectl:1.23.5-debian-10-r30@sha256:d0e24ae78c1f70fa347b5ca9518d91d9a65a29ca8e38e936123746f4d70b9cdb
         command: ["sh", "-c", "timeout 3m bash -c 'until kubectl get crd {{ range $kinds | uniq }}{{ (lower .) }}.constraints.gatekeeper.sh {{ end }}; do sleep 1; done'"]


### PR DESCRIPTION
Bitnami seems to have removed all of their quay images so need to replace it with something else.