### PR TITLE
Update name to match ingress class instead of pod class

### DIFF
--- a/charts/gatekeeper-library-templates/generated/k8srequireingressclass.yaml
+++ b/charts/gatekeeper-library-templates/generated/k8srequireingressclass.yaml
@@ -1,12 +1,12 @@
 apiVersion: templates.gatekeeper.sh/v1
 kind: ConstraintTemplate
 metadata:
-  name: k8spodpriorityclass
+  name: k8srequireingressclass
 spec:
   crd:
     spec:
       names:
-        kind: K8sPodPriorityClass
+        kind: K8sRequireIngressClass
       validation:
         openAPIV3Schema:
           properties:

--- a/library/constraints/require-ingress-class/template.yaml
+++ b/library/constraints/require-ingress-class/template.yaml
@@ -1,12 +1,12 @@
 apiVersion: templates.gatekeeper.sh/v1
 kind: ConstraintTemplate
 metadata:
-  name: k8spodpriorityclass
+  name: k8srequireingressclass
 spec:
   crd:
     spec:
       names:
-        kind: K8sPodPriorityClass
+        kind: K8sRequireIngressClass
       validation:
         openAPIV3Schema:
           type: object


### PR DESCRIPTION
Fixes a bug from: https://github.com/XenitAB/gatekeeper-library/pull/70 that used the same name as another constraints. Therefore hard to use it, I assume that the rule that comes last is actually the one that is applied but I don't know.
When this gets merged we will release a minor bug fix.
