### PR TITLE
Add mutation for ephemeral containers

### DIFF
--- a/charts/gatekeeper-library-constraints/generated/ephemeral-container-disallow-privilege-escalation.yaml
+++ b/charts/gatekeeper-library-constraints/generated/ephemeral-container-disallow-privilege-escalation.yaml
@@ -1,0 +1,18 @@
+apiVersion: mutations.gatekeeper.sh/v1beta1
+kind: Assign
+metadata:
+  name: ephemeral-container-disallow-privilege-escalation
+spec:
+  match:
+    scope: Namespaced
+    kinds:
+      - apiGroups: ["*"]
+        kinds: ["Pod"]
+  applyTo:
+    - versions: ["v1"]
+      groups: [""]
+      kinds: ["Pod"]
+  location: "spec.ephemeralContainers[name:*].securityContext.allowPrivilegeEscalation"
+  parameters:
+    assign:
+      value: false

--- a/charts/gatekeeper-library-constraints/generated/ephemeral-container-drop-capabilities.yaml
+++ b/charts/gatekeeper-library-constraints/generated/ephemeral-container-drop-capabilities.yaml
@@ -1,0 +1,20 @@
+apiVersion: mutations.gatekeeper.sh/v1beta1
+kind: Assign
+metadata:
+  name: ephemeral-container-drop-capabilities
+spec:
+  match:
+    scope: Namespaced
+    kinds:
+      - apiGroups: ["*"]
+        kinds: ["Pod"]
+  applyTo:
+    - groups: [""]
+      versions: ["v1"]
+      kinds: ["Pod"]
+  location: "spec.ephemeralContainers[name:*].securityContext.capabilities.drop"
+  parameters:
+    assign:
+      value:
+        - NET_RAW
+        - CAP_SYS_ADMIN

--- a/charts/gatekeeper-library-constraints/generated/ephemeral-container-read-only-root-fs.yaml
+++ b/charts/gatekeeper-library-constraints/generated/ephemeral-container-read-only-root-fs.yaml
@@ -1,0 +1,18 @@
+apiVersion: mutations.gatekeeper.sh/v1beta1
+kind: Assign
+metadata:
+  name: ephemeral-container-read-only-root-fs
+spec:
+  match:
+    scope: Namespaced
+    kinds:
+      - apiGroups: ["*"]
+        kinds: ["Pod"]
+  applyTo:
+    - groups: [""]
+      versions: ["v1"]
+      kinds: ["Pod"]
+  location: "spec.ephemeralContainers[name:*].securityContext.readOnlyRootFilesystem"
+  parameters:
+    assign:
+      value: true

--- a/library/assigns/ephemeral-container-disallow-privilege-escalation.yaml
+++ b/library/assigns/ephemeral-container-disallow-privilege-escalation.yaml
@@ -1,0 +1,18 @@
+apiVersion: mutations.gatekeeper.sh/v1beta1
+kind: Assign
+metadata:
+  name: ephemeral-container-disallow-privilege-escalation
+spec:
+  match:
+    scope: Namespaced
+    kinds:
+      - apiGroups: ["*"]
+        kinds: ["Pod"]
+  applyTo:
+    - versions: ["v1"]
+      groups: [""]
+      kinds: ["Pod"]
+  location: "spec.ephemeralContainers[name:*].securityContext.allowPrivilegeEscalation"
+  parameters:
+    assign:
+      value: false

--- a/library/assigns/ephemeral-container-drop-capabilities.yaml
+++ b/library/assigns/ephemeral-container-drop-capabilities.yaml
@@ -1,0 +1,20 @@
+apiVersion: mutations.gatekeeper.sh/v1beta1
+kind: Assign
+metadata:
+  name: ephemeral-container-drop-capabilities
+spec:
+  match:
+    scope: Namespaced
+    kinds:
+      - apiGroups: ["*"]
+        kinds: ["Pod"]
+  applyTo:
+    - groups: [""]
+      versions: ["v1"]
+      kinds: ["Pod"]
+  location: "spec.ephemeralContainers[name:*].securityContext.capabilities.drop"
+  parameters:
+    assign:
+      value:
+        - NET_RAW
+        - CAP_SYS_ADMIN

--- a/library/assigns/ephemeral-container-read-only-root-fs.yaml
+++ b/library/assigns/ephemeral-container-read-only-root-fs.yaml
@@ -1,0 +1,18 @@
+apiVersion: mutations.gatekeeper.sh/v1beta1
+kind: Assign
+metadata:
+  name: ephemeral-container-read-only-root-fs
+spec:
+  match:
+    scope: Namespaced
+    kinds:
+      - apiGroups: ["*"]
+        kinds: ["Pod"]
+  applyTo:
+    - groups: [""]
+      versions: ["v1"]
+      kinds: ["Pod"]
+  location: "spec.ephemeralContainers[name:*].securityContext.readOnlyRootFilesystem"
+  parameters:
+    assign:
+      value: true


### PR DESCRIPTION
I have tried to use this pr but I'm unable to get it to work.
I still get validation errors.

This have been tested together with https://github.com/XenitAB/terraform-modules/pull/881
And we know that this works since it works with linkerd.

I have tried by running

```shell
kubectl run -i -t busybox --image=busybox --restart=Never
kubectl debug busybox --image=golang:1.19.3-alpine3.16 -i -t -- /bin/sh
Defaulting debug container name to debugger-j2g7s.

Error from server (Forbidden): admission webhook "validation.gatekeeper.sh" denied the request: [psp-allow-privilege-escalation-container] Privilege escalation container is not allowed: debugger-j2g7s
[psp-capabilities] ephemeral container <debugger-j2g7s> is not dropping all required capabilities. Container must drop all of ["NET_RAW", "CAP_SYS_ADMIN"] or "ALL"
[psp-readonlyrootfilesystem] only read-only root filesystem container is allowed: debugger-j2g7s
```

My current thought is that it's some other API that I also need to listen to but I'm unable to find it.
Or that the gatekeeper assign don't work with ephemeralContainers for some reason.

I think that 

```shell
k get validatingwebhookconfigurations.admissionregistration.k8s.io gatekeeper-validating-webhook-configuration
k get mutatingwebhookconfigurations.admissionregistration.k8s.io gatekeeper-mutating-webhook-configuration
```

Looks okay.